### PR TITLE
Allow for document to be provided programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,44 @@ var listener = app.listen(process.env.PORT || 3000, function() {
   console.log('FastBoot running at http://' + host + ":" + port);
 });
 ```
+
+#### Providing Index Document Programmatically
+
+You may not store `index.html` with the fastboot build, perhaps it's
+stored on an external server, or want to preload the document with additional
+information such as i18n translations.  To do this, first, omit `htmlFile` from the options hash
+that is provided to the `FastBootServer` constructor.
+
+Next, register a middleware _before_ `server.middleware`, retrieve your index file,
+or read it from disk and manipulate the content.  Finally, set the final value to `res.locals.fastbootHTML`.
+
+```js
+var fetchIndex = require('node-ember-cli-deploy-redis/fetch');
+
+var server = new FastBootServer({
+  distPath: 'path/to/fastboot-dist'
+});
+
+var app = express();
+
+app.use(function(req, res, next) {
+  fetchIndex(req, 'myapp:index', {
+    host: 'redis.example.org',
+    port: 6929,
+    password: 'passw0rd!',
+    db: 0
+  }).then(function(indexHtml) {
+    res.locals.fastbootHTML = indexHtml;
+    next();
+  }).catch(next);
+});
+
+app.get('/*', server.middleware());
+
+var listener = app.listen(process.env.PORT || 3000, function() {
+  var host = listener.address().address;
+  var port = listener.address().port;
+
+  console.log('FastBoot running at http://' + host + ":" + port);
+});
+```

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,9 @@ function FastBootServer(options) {
     moduleWhitelist: config.moduleWhitelist
   });
 
-  this.html = fs.readFileSync(config.htmlFile, 'utf8');
+  if (config.htmlFile) {
+    this.html = fs.readFileSync(config.htmlFile, 'utf8');
+  }
 
   this.ui = options.ui || defaultUI;
 }
@@ -39,8 +41,8 @@ FastBootServer.prototype.log = function(statusCode, message, startTime) {
   this.ui.writeLine(chalk.blue(now.toISOString()) + " " + chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body, head) {
-  var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
+FastBootServer.prototype.insertIntoIndexHTML = function(html, title, body, head) {
+  html = html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
 
   if (title) {
     html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + title + "</title>");
@@ -54,7 +56,7 @@ FastBootServer.prototype.insertIntoIndexHTML = function(title, body, head) {
 
 FastBootServer.prototype.handleSuccess = function(res, path, result, startTime) {
   this.log(200, 'OK ' + path, startTime);
-  res.send(this.insertIntoIndexHTML(result.title, result.body, result.head));
+  res.send(this.insertIntoIndexHTML(res.locals.fastbootHTML, result.title, result.body, result.head));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error, startTime) {
@@ -76,6 +78,10 @@ FastBootServer.prototype.handleAppBootFailure = function(error) {
 
 FastBootServer.prototype.middleware = function() {
   return function(req, res, next) {
+    if (this.html) {
+      res.locals.fastbootHTML = this.html;
+    }
+
     var path = req.path;
     debug("middleware request; path=%s", path);
 


### PR DESCRIPTION
This adds the ability for an upstream middleware to provide the document through `res.locals.fastbootHTML` versus loading it from disk.  This enables setting the initial title, meta tags, pulling it from a redis server, preloading the document with translations based on the requested url, etc. etc.