### PR TITLE
Add ENV to fastboot-info

### DIFF
--- a/lib/fastboot-info.js
+++ b/lib/fastboot-info.js
@@ -11,6 +11,7 @@ function FastBootInfo(request, response, hostWhitelist) {
   this.deferredPromise = RSVP.resolve();
   this.request = new FastBootRequest(request, hostWhitelist);
   this.response = new FastBootResponse(response);
+  this.ENV = process.env;
 }
 
 FastBootInfo.prototype.deferRendering = function(promise) {

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -31,5 +31,8 @@ describe("FastBootInfo", function() {
   it("has a FastBootResponse", function() {
     expect(fastbootInfo.response).to.be.an.instanceOf(FastBootResponse);
   });
-});
 
+  it("has an ENV", function() {
+    expect(fastbootInfo.ENV).to.be.an('object');
+  });
+});


### PR DESCRIPTION
We'd like to be able to pass ENV information to the Ember app so we can use the same build in production & staging (pre-production) but with different API keys/hostnames/etc.

This is a pretty brain-dead method of doing that but it works for us. Hopefully it's at least a starting point for a discussion.