### PR TITLE
Return appropriate message bodies for 3XX and 204 responses

### DIFF
--- a/lib/fastboot-request.js
+++ b/lib/fastboot-request.js
@@ -32,7 +32,7 @@ FastBootRequest.prototype.host = function() {
   }, false);
 
   if (!matchFound) {
-    throw new Error('The host header did not match a hostWhitelist entry');
+    throw new Error(`The host header did not match a hostWhitelist entry. Host header: ${host}`);
   }
 
   return host;

--- a/lib/result.js
+++ b/lib/result.js
@@ -25,7 +25,11 @@ class Result {
     let response = this._fastbootInfo.response;
     let statusCode = response && this._fastbootInfo.response.statusCode;
 
-    if (statusCode >= 300 && statusCode <= 399) {
+    if (statusCode === 204) {
+      this._html = '';
+      this._head = '';
+      this._body = '';
+    } else if (statusCode >= 300 && statusCode <= 399) {
       let location = response.headers.get('location');
 
       this._html = '<body><!-- EMBER_CLI_FASTBOOT_BODY --></body>';

--- a/lib/result.js
+++ b/lib/result.js
@@ -22,6 +22,21 @@ class Result {
    * @returns {Promise<String>} the application's DOM serialized to HTML
    */
   html() {
+    let response = this._fastbootInfo.response;
+    let statusCode = response && this._fastbootInfo.response.statusCode;
+
+    if (statusCode >= 300 && statusCode <= 399) {
+      let location = response.headers.get('location');
+
+      this._html = '<body><!-- EMBER_CLI_FASTBOOT_BODY --></body>';
+      this._head = '';
+      this._body = '';
+
+      if (location) {
+        this._body = `<h1>Redirecting to <a href="${location}">${location}</a></h1>`;
+      }
+    }
+
     return Promise.resolve(insertIntoIndexHTML(this._html, this._head, this._body));
   }
 

--- a/test/fastboot-request-test.js
+++ b/test/fastboot-request-test.js
@@ -38,7 +38,7 @@ describe("FastBootRequest", function() {
     var fn = function() {
       fastbootRequest.host();
     };
-    expect(fn).to.throw(/The host header did not match a hostWhitelist entry/);
+    expect(fn).to.throw(/The host header did not match a hostWhitelist entry. Host header: evil.com/);
   });
 
   it("returns the host if it is in the hostWhitelist", function() {

--- a/test/fastboot-response-test.js
+++ b/test/fastboot-response-test.js
@@ -1,5 +1,4 @@
 var expect = require('chai').expect;
-var path = require('path');
 var FastBootHeaders = require('../lib/fastboot-headers.js');
 var FastBootResponse = require('../lib/fastboot-response.js');
 

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -1,0 +1,71 @@
+var expect = require('chai').expect;
+var Result = require('../lib/result.js');
+var FastBootInfo = require('../lib/fastboot-info.js');
+var SimpleDOM = require('simple-dom');
+
+describe('Result', function() {
+  var doc, result;
+
+  beforeEach(function () {
+    var req = { get() {} };
+
+    doc = new SimpleDOM.Document();
+    html = `<!-- EMBER_CLI_FASTBOOT_HEAD -->
+            <!-- EMBER_CLI_FASTBOOT_BODY -->`;
+
+    result = new Result({
+      doc: doc,
+      html: html,
+      fastbootInfo: new FastBootInfo(req, {}, [ 'example.com' ])
+    });
+  });
+
+  it('constructor', function () {
+    expect(result).to.be.an.instanceOf(Result);
+    expect(result._doc).to.be.an.instanceOf(SimpleDOM.Document);
+    expect(result._html).to.be.a('string');
+    expect(result._fastbootInfo).to.be.an.instanceOf(FastBootInfo);
+  });
+
+  describe('html()', function () {
+
+    describe('when the response status code is 3XX', function () {
+      beforeEach(function () {
+        result._fastbootInfo.response.headers.set('location', 'http://some.example.com/page');
+        result._fastbootInfo.response.statusCode = 307;
+        result._finalize();
+      });
+
+      it('should return a document body with redirect information', function () {
+        return result.html()
+        .then(function (result) {
+          expect(result).to.include('<body>');
+          expect(result).to.include('Redirecting to');
+          expect(result).to.include('http://some.example.com/page');
+          expect(result).to.include('</body>');
+        });
+      });
+    });
+
+    describe('when the response status code is not 3XX', function () {
+      var HEAD = '<meta name="foo" content="bar">';
+      var BODY = '<h1>A normal response document</h1>';
+
+      beforeEach(function () {
+        doc.head.appendChild(doc.createRawHTMLSection(HEAD));
+        doc.body.appendChild(doc.createRawHTMLSection(BODY));
+
+        result._fastbootInfo.response.statusCode = 418;
+        result._finalize();
+      });
+
+      it('should return the FastBoot-rendered document body', function () {
+        return result.html()
+        .then(function (result) {
+          expect(result).to.include(HEAD);
+          expect(result).to.include(BODY);
+        });
+      });
+    });
+  });
+});

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -29,6 +29,20 @@ describe('Result', function() {
 
   describe('html()', function () {
 
+    describe('when the response status code is 204', function () {
+      beforeEach(function () {
+        result._fastbootInfo.response.statusCode = 204;
+        result._finalize();
+      });
+
+      it('should return an empty message body', function () {
+        return result.html()
+        .then(function (result) {
+          expect(result).to.equal('');
+        });
+      });
+    });
+
     describe('when the response status code is 3XX', function () {
       beforeEach(function () {
         result._fastbootInfo.response.headers.set('location', 'http://some.example.com/page');
@@ -47,7 +61,7 @@ describe('Result', function() {
       });
     });
 
-    describe('when the response status code is not 3XX', function () {
+    describe('when the response status code is not 3XX or 204', function () {
       var HEAD = '<meta name="foo" content="bar">';
       var BODY = '<h1>A normal response document</h1>';
 


### PR DESCRIPTION
@tomdale @danmcclain,

Though, not always required by [spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html), we should avoid returning any serialized HTML for `3xx` status codes because, 

1. the rendered HTML returned from the Ember App is sometimes incorrect (the wrong page is rendered) and;
2. the rendered HTML might allow the user access to pages they were not supposed to see.

Related to https://github.com/ember-fastboot/ember-cli-fastboot/pull/195.

If this implementation looks good let me know and I will add test cases.