### PR TITLE
Made request compatible with nodejs' ClientRequest instances.

### DIFF
--- a/lib/fastboot-request.js
+++ b/lib/fastboot-request.js
@@ -46,7 +46,7 @@ FastBootRequest.prototype.extractCookies = function(request) {
   }
 
   // Otherwise, try to parse the cookies ourselves, if they exist.
-  var cookies = request.get('cookie');
+  var cookies = request.headers.cookie;
   if (cookies) {
     return cookie.parse(cookies);
   }

--- a/lib/fastboot-response.js
+++ b/lib/fastboot-response.js
@@ -1,7 +1,7 @@
 var FastBootHeaders = require('./fastboot-headers');
 
 function FastbootResponse(response) {
-  this.headers = new FastBootHeaders(response.headers);
+  this.headers = new FastBootHeaders(response._headers);
   this.statusCode = 200;
 }
 

--- a/test/fastboot-request-test.js
+++ b/test/fastboot-request-test.js
@@ -5,12 +5,9 @@ var FastBootRequest = require('../lib/fastboot-request.js');
 describe("FastBootRequest", function() {
   it("throws an exception if no hostWhitelist is provided", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       headers: {
-      },
-      get: function() {
-        return this.cookie;
+        cookie: ""
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -23,13 +20,10 @@ describe("FastBootRequest", function() {
 
   it("throws an exception if the host header does not match an entry in the hostWhitelist", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       headers: {
-        host: "evil.com"
-      },
-      get: function() {
-        return this.cookie;
+        host: "evil.com",
+        cookie: ""
       }
     };
     var hostWhitelist = ["example.com", "localhost:4200"];
@@ -43,13 +37,10 @@ describe("FastBootRequest", function() {
 
   it("returns the host if it is in the hostWhitelist", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       headers: {
-        host: "localhost:4200"
-      },
-      get: function() {
-        return this.cookie;
+        host: "localhost:4200",
+        cookie: ""
       }
     };
     var hostWhitelist = ["example.com", "localhost:4200"];
@@ -61,13 +52,10 @@ describe("FastBootRequest", function() {
 
   it("returns the host if it matches a regex in the hostWhitelist", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       headers: {
-        host: "localhost:4200"
-      },
-      get: function() {
-        return this.cookie;
+        host: "localhost:4200",
+        cookie: ""
       }
     };
     var hostWhitelist = ["example.com", "/localhost:\\d+/"];
@@ -79,13 +67,12 @@ describe("FastBootRequest", function() {
 
   it("captures the query params from the request", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       query: {
         foo: "bar"
       },
-      get: function() {
-        return this.cookie;
+      headers: {
+        cookie: ""
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -95,12 +82,10 @@ describe("FastBootRequest", function() {
 
   it("captures the path from the request", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       url: "/foo",
-
-      get: function() {
-        return this.cookie;
+      headers: {
+        cookie: ""
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -110,15 +95,11 @@ describe("FastBootRequest", function() {
 
   it("captures the headers from the request", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       url: "/foo",
       headers: {
-        host: "localhost:4200"
-      },
-
-      get: function() {
-        return this.cookie;
+        host: "localhost:4200",
+        cookie: ""
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -128,15 +109,11 @@ describe("FastBootRequest", function() {
 
   it("captures the protocol from the request", function() {
     var request = {
-      cookie: "",
       protocol: "http",
       url: "/foo",
       headers: {
-        host: "localhost:4200"
-      },
-
-      get: function() {
-        return this.cookie;
+        host: "localhost:4200",
+        cookie: ""
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -146,15 +123,11 @@ describe("FastBootRequest", function() {
 
   it("captures the cookies from the request", function() {
     var request = {
-      cookie: "test=bar",
       protocol: "http",
       url: "/foo",
       headers: {
-        host: "localhost:4200"
-      },
-
-      get: function() {
-        return this.cookie;
+        host: "localhost:4200",
+        cookie: "test=bar"
       }
     };
     var fastbootRequest = new FastBootRequest(request);
@@ -162,4 +135,3 @@ describe("FastBootRequest", function() {
     expect(fastbootRequest.cookies.test).to.equal("bar");
   });
 });
-

--- a/test/fastboot-response-test.js
+++ b/test/fastboot-response-test.js
@@ -8,11 +8,9 @@ describe("FastBootResponse", function() {
 
   beforeEach(function () {
     var mockResponse = {
-      headers: {
-        "i-am-a": "mock header, me too"
-      },
-      get: function () {
-        return this.headers.cookie;
+      _headers: {
+        "i-am-a": "mock header, me too",
+        "cookie": ""
       }
     };
 
@@ -44,4 +42,3 @@ describe("FastBootResponse", function() {
     });
   });
 });
-


### PR DESCRIPTION
Hi there,

As mentioned by the _EmberApp_ class, the visit options should expect a ClientRequest instance;

```
* If this call to `visit()` is to service an incoming HTTP request, you may
* provide Node's `ClientRequest` and `ServerResponse` objects as options
* (e.g., the `res` and `req` arguments passed to Express middleware).  These
* are provided to the Ember application via the FastBoot service.
```

But internally, it calls the _get('cookie')_ method to get the cookie for a request, which belongs to the Express API. I changed the call to make the code compatible with other frameworks like Hapi.js.

Cheers,
Robin