### PR TITLE
Don't obscure errors during instance creation

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -223,7 +223,11 @@ class EmberApp {
       .then(() => createShoebox(doc, fastbootInfo))
       .catch(error => result.error = error)
       .then(() => result._finalize())
-      .finally(() => instance.destroy());
+      .finally(() => {
+        if (instance) {
+          instance.destroy();
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
If `buildAppInstance` throws an exception, that exception gets swallowed when the `finally` handler fails because `instance` is undefined.