### PR TITLE
Only access instance.getURL if the instance has booted

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -190,7 +190,7 @@ class EmberApp {
    * @param {string} path the URL path to render, like `/photos/1`
    * @param {Object} options
    * @param {string} [options.html] the HTML document to insert the rendered app into
-   * @param {ClientRequest} 
+   * @param {ClientRequest}
    * @returns {Promise<Result>} result
    */
   visit(path, options) {
@@ -218,6 +218,7 @@ class EmberApp {
 
         return instance.boot(bootOptions);
       })
+      .then(() => result.instanceBooted = true)
       .then(() => instance.visit(path, bootOptions))
       .then(() => waitForApp(instance))
       .then(() => createShoebox(doc, fastbootInfo))

--- a/lib/result.js
+++ b/lib/result.js
@@ -10,6 +10,7 @@ const HTMLSerializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
  */
 class Result {
   constructor(options) {
+    this.instanceBooted = false;
     this._doc = options.doc;
     this._html = options.html;
     this._fastbootInfo = options.fastbootInfo;
@@ -71,7 +72,9 @@ class Result {
   }
 
   _finalizeMetadata(instance) {
-    this.url = instance.getURL();
+    if (this.instanceBooted) {
+      this.url = instance.getURL();
+    }
 
     let response = this._fastbootInfo.response;
 


### PR DESCRIPTION
Accessing it if the instance failed to boot causes [Ember's router to try and access `location.getURL`](https://github.com/ember-fastboot/fastboot/pull/71) when `location` is a string (`"none"`) instead the expected `Ember.NoneLocation` instance.

This is leading to all uncaught errors that occur during the app boot to be masked/swallowed.

https://github.com/ember-fastboot/ember-cli-fastboot/issues/223

I can send a fix into Ember to not invoke`getURL` when the location object was not created.