### PR TITLE
Add metadata option for .visit

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -202,7 +202,7 @@ class EmberApp {
     let fastbootInfo = new FastBootInfo(
       req,
       res,
-      { hostWhitelist: this.hostWhitelist, metaData: options.metaData }
+      { hostWhitelist: this.hostWhitelist, metadata: options.metadata }
     );
     let doc = bootOptions.document;
 

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -199,7 +199,11 @@ class EmberApp {
     let html = options.html || this.html;
 
     let bootOptions = buildBootOptions();
-    let fastbootInfo = new FastBootInfo(req, res, this.hostWhitelist);
+    let fastbootInfo = new FastBootInfo(
+      req,
+      res,
+      { hostWhitelist: this.hostWhitelist, metaData: options.metaData }
+    );
     let doc = bootOptions.document;
 
     let instance;

--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -8,7 +8,7 @@ var FastBootResponse = require('./fastboot-response');
  * on to the FastBoot service.
  */
 function FastBootInfo(request, response, options = {}) {
-  const { hostWhitelist, metaData } = options;
+  const { hostWhitelist, metadata } = options;
 
   this.deferredPromise = RSVP.resolve();
   if (request) {
@@ -16,7 +16,7 @@ function FastBootInfo(request, response, options = {}) {
   }
 
   this.response = new FastBootResponse(response || {});
-  this.metaData = metaData;
+  this.metadata = metadata;
 }
 
 FastBootInfo.prototype.deferRendering = function(promise) {

--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -7,13 +7,16 @@ var FastBootResponse = require('./fastboot-response');
  * current HTTP request from FastBoot. This is injected
  * on to the FastBoot service.
  */
-function FastBootInfo(request, response, hostWhitelist) {
+function FastBootInfo(request, response, options = {}) {
+  const { hostWhitelist, metaData } = options;
+
   this.deferredPromise = RSVP.resolve();
   if (request) {
     this.request = new FastBootRequest(request, hostWhitelist);
   }
 
   this.response = new FastBootResponse(response || {});
+  this.metaData = metaData;
 }
 
 FastBootInfo.prototype.deferRendering = function(promise) {

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -9,6 +9,7 @@ describe("FastBootInfo", function() {
   var response;
   var request;
   var fastbootInfo;
+  var metadata = { foo: 'bar' };
 
   beforeEach(function () {
     response = {};
@@ -22,7 +23,7 @@ describe("FastBootInfo", function() {
       }
     };
 
-    fastbootInfo = new FastBootInfo(request, response);
+    fastbootInfo = new FastBootInfo(request, response, { metadata });
   });
 
   it("has a FastBootRequest", function() {
@@ -32,5 +33,8 @@ describe("FastBootInfo", function() {
   it("has a FastBootResponse", function() {
     expect(fastbootInfo.response).to.be.an.instanceOf(FastBootResponse);
   });
-});
 
+  it("has metadata", function() {
+    expect(fastbootInfo.metadata).to.deep.equal(metadata);
+  });
+});


### PR DESCRIPTION
Allows an option of metadata to be passed into options like:
```js
fastboot.visit('...', { metadata: { foo: 'bar' } });
```

This enables per request information to be passed into the app such as user session info.

Related service change: https://github.com/ember-fastboot/ember-cli-fastboot/pull/245