### PR TITLE
Shoebox encoding

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -311,7 +311,7 @@ function createShoebox(doc, fastbootInfo) {
 
     let value = shoebox[key];
     let textValue = JSON.stringify(value);
-    textValue = textValue.replace(/<\/(script)/i, '<\\/$1');
+    textValue = textValue.replace(/<\/(script[ />])/i, '<\\/$1');
 
     let scriptText = doc.createRawHTMLSection(textValue);
     let scriptEl = doc.createElement('script');

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -310,7 +310,10 @@ function createShoebox(doc, fastbootInfo) {
     if (!shoebox.hasOwnProperty(key)) { continue; }
 
     let value = shoebox[key];
-    let scriptText = doc.createRawHTMLSection(JSON.stringify(value));
+    let textValue = JSON.stringify(value);
+    textValue = textValue.replace('</script', '<\\/script');
+
+    let scriptText = doc.createRawHTMLSection(textValue);
     let scriptEl = doc.createElement('script');
 
     scriptEl.setAttribute('type', 'fastboot/shoebox');

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -310,7 +310,7 @@ function createShoebox(doc, fastbootInfo) {
     if (!shoebox.hasOwnProperty(key)) { continue; }
 
     let value = shoebox[key];
-    let scriptText = doc.createTextNode(JSON.stringify(value));
+    let scriptText = doc.createRawHTMLSection(JSON.stringify(value));
     let scriptEl = doc.createElement('script');
 
     scriptEl.setAttribute('type', 'fastboot/shoebox');

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -311,7 +311,7 @@ function createShoebox(doc, fastbootInfo) {
 
     let value = shoebox[key];
     let textValue = JSON.stringify(value);
-    textValue = textValue.replace('</script', '<\\/script');
+    textValue = textValue.replace(/<\/(script)/i, '<\\/$1');
 
     let scriptText = doc.createRawHTMLSection(textValue);
     let scriptEl = doc.createElement('script');

--- a/test/fastboot-shoebox-test.js
+++ b/test/fastboot-shoebox-test.js
@@ -20,7 +20,12 @@ describe("FastBootShoebox", function() {
       .then(html => {
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key1">{"foo":"bar"}<\/script>/);
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key2">{"zip":"zap"}<\/script>/);
+
+        // HTML special characters are not encoded
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key3">{"htmlSpecialCase":"R&B > Jazz"}<\/script>/);
+
+        // "</script" is escaped as "<\/script" (valid in JSON)
+        expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key4">{"nastyScriptCase":"1337 hackz0rz RULe <\\\/script d00d>"}<\/script>/);
       });
   });
 

--- a/test/fastboot-shoebox-test.js
+++ b/test/fastboot-shoebox-test.js
@@ -25,7 +25,7 @@ describe("FastBootShoebox", function() {
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key3">{"htmlSpecialCase":"R&B > Jazz"}<\/script>/);
 
         // "</script" is escaped as "<\/script" (valid in JSON)
-        expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key4">{"nastyScriptCase":"1337 hackz0rz RULe <\\\/script d00d>"}<\/script>/);
+        expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key4">{"nastyScriptCase":"1337 hackz0rz RULe <\\\/ScRiPt d00d>"}<\/script>/);
       });
   });
 

--- a/test/fastboot-shoebox-test.js
+++ b/test/fastboot-shoebox-test.js
@@ -20,6 +20,7 @@ describe("FastBootShoebox", function() {
       .then(html => {
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key1">{"foo":"bar"}<\/script>/);
         expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key2">{"zip":"zap"}<\/script>/);
+        expect(html).to.match(/<script type="fastboot\/shoebox" id="shoebox-key3">{"htmlSpecialCase":"R&B > Jazz"}<\/script>/);
       });
   });
 

--- a/test/fixtures/shoebox/fastboot/fastboot-test.js
+++ b/test/fixtures/shoebox/fastboot/fastboot-test.js
@@ -298,7 +298,7 @@ define('fastboot-test/routes/application', ['exports', 'ember'], function (expor
         shoebox.put('key1', { foo: 'bar' });
         shoebox.put('key2', { zip: 'zap' });
         shoebox.put('key3', { htmlSpecialCase: 'R&B > Jazz' });
-        shoebox.put('key4', { nastyScriptCase: '1337 hackz0rz RULe </script d00d>' });
+        shoebox.put('key4', { nastyScriptCase: '1337 hackz0rz RULe </ScRiPt d00d>' });
       }
     }
   });

--- a/test/fixtures/shoebox/fastboot/fastboot-test.js
+++ b/test/fixtures/shoebox/fastboot/fastboot-test.js
@@ -67,7 +67,7 @@ define('fastboot-test/initializers/data-adapter', ['exports', 'ember'], function
   /*
     This initializer is here to keep backwards compatibility with code depending
     on the `data-adapter` initializer (before Ember Data was an addon).
-  
+
     Should be removed for Ember Data 3.x
   */
 
@@ -80,31 +80,31 @@ define('fastboot-test/initializers/data-adapter', ['exports', 'ember'], function
 define('fastboot-test/initializers/ember-data', ['exports', 'ember-data/setup-container', 'ember-data/-private/core'], function (exports, _emberDataSetupContainer, _emberDataPrivateCore) {
 
   /*
-  
+
     This code initializes Ember-Data onto an Ember application.
-  
+
     If an Ember.js developer defines a subclass of DS.Store on their application,
     as `App.StoreService` (or via a module system that resolves to `service:store`)
     this code will automatically instantiate it and make it available on the
     router.
-  
+
     Additionally, after an application's controllers have been injected, they will
     each have the store made available to them.
-  
+
     For example, imagine an Ember.js application with the following classes:
-  
+
     App.StoreService = DS.Store.extend({
       adapter: 'custom'
     });
-  
+
     App.PostsController = Ember.ArrayController.extend({
       // ...
     });
-  
+
     When the application is initialized, `App.ApplicationStore` will automatically be
     instantiated, and the instance of `App.PostsController` will have its `store`
     property set to that instance.
-  
+
     Note that this code will only be run if the `ember-application` package is
     loaded. If Ember Data is being used in an environment other than a
     typical application (e.g., node.js where only `ember-runtime` is available),
@@ -227,7 +227,7 @@ define('fastboot-test/initializers/injectStore', ['exports', 'ember'], function 
   /*
     This initializer is here to keep backwards compatibility with code depending
     on the `injectStore` initializer (before Ember Data was an addon).
-  
+
     Should be removed for Ember Data 3.x
   */
 
@@ -242,7 +242,7 @@ define('fastboot-test/initializers/store', ['exports', 'ember'], function (expor
   /*
     This initializer is here to keep backwards compatibility with code depending
     on the `store` initializer (before Ember Data was an addon).
-  
+
     Should be removed for Ember Data 3.x
   */
 
@@ -257,7 +257,7 @@ define('fastboot-test/initializers/transforms', ['exports', 'ember'], function (
   /*
     This initializer is here to keep backwards compatibility with code depending
     on the `transforms` initializer (before Ember Data was an addon).
-  
+
     Should be removed for Ember Data 3.x
   */
 
@@ -297,6 +297,7 @@ define('fastboot-test/routes/application', ['exports', 'ember'], function (expor
       if (fastboot.get('isFastBoot')) {
         shoebox.put('key1', { foo: 'bar' });
         shoebox.put('key2', { zip: 'zap' });
+        shoebox.put('key3', { htmlSpecialCase: 'R&B > Jazz' });
       }
     }
   });

--- a/test/fixtures/shoebox/fastboot/fastboot-test.js
+++ b/test/fixtures/shoebox/fastboot/fastboot-test.js
@@ -298,6 +298,7 @@ define('fastboot-test/routes/application', ['exports', 'ember'], function (expor
         shoebox.put('key1', { foo: 'bar' });
         shoebox.put('key2', { zip: 'zap' });
         shoebox.put('key3', { htmlSpecialCase: 'R&B > Jazz' });
+        shoebox.put('key4', { nastyScriptCase: '1337 hackz0rz RULe </script d00d>' });
       }
     }
   });


### PR DESCRIPTION
SimpleDOM [escapes `&`, `<` and `>`](https://github.com/ember-fastboot/simple-dom/blob/80ecb54/lib/simple-dom/html-serializer.js#L46-L57) when it serializes text nodes, so our Shoebox payload gets garbled. Use [`createRawHTMLSection`](https://github.com/ember-fastboot/simple-dom/blob/80ecb54/lib/simple-dom/html-serializer.js#L63-L65), instead.

