### PR TITLE
WIP: allow priming the shoebox from express

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -196,10 +196,11 @@ class EmberApp {
   visit(path, options) {
     let req = options.request;
     let res = options.response;
+    let shoebox = options.shoebox;
     let html = options.html || this.html;
 
     let bootOptions = buildBootOptions();
-    let fastbootInfo = new FastBootInfo(req, res, this.hostWhitelist);
+    let fastbootInfo = new FastBootInfo(req, res, shoebox, this.hostWhitelist);
     let doc = bootOptions.document;
 
     let instance;

--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -7,13 +7,14 @@ var FastBootResponse = require('./fastboot-response');
  * current HTTP request from FastBoot. This is injected
  * on to the FastBoot service.
  */
-function FastBootInfo(request, response, hostWhitelist) {
+function FastBootInfo(request, response, shoebox, hostWhitelist) {
   this.deferredPromise = RSVP.resolve();
   if (request) {
     this.request = new FastBootRequest(request, hostWhitelist);
   }
 
   this.response = new FastBootResponse(response || {});
+  this.shoebox = shoebox;
 }
 
 FastBootInfo.prototype.deferRendering = function(promise) {


### PR DESCRIPTION
Resolves #82.

Lets you provide state to ember from express.

```js
app.visit('/photos', {
  shoebox: {
    // ...
  }
}).then(// ...
```

Is working perfectly in my app.

Unresolved:
 - [ ] Is this the best API? Should it be supplied in `new FastBoot` or `visit`?
 - [ ] Add tests once the API is approved.
 - [ ] Add docs