### PR TITLE
handle headers as both strings and arrays

### DIFF
--- a/src/fastboot-headers.js
+++ b/src/fastboot-headers.js
@@ -5,7 +5,14 @@ function FastBootHeaders(headers) {
   this.headers = {};
 
   for (var header in headers) {
-    this.headers[header] = headers[header].split(', ');
+    let value = headers[header];
+
+    // convert to array if not already
+    if (typeof value === 'string') {
+      value = value.split(', ');
+    }
+
+    this.headers[header] = value;
   }
 }
 

--- a/test/fastboot-headers-test.js
+++ b/test/fastboot-headers-test.js
@@ -68,6 +68,15 @@ describe('FastBootHeaders', function() {
     expect(headers.has('host')).to.be.false;
   });
 
+  it('handles header values that are already an array', function() {
+    var headers = {
+      'x-test-header': ['value1', 'value2']
+    };
+    headers = new FastBootHeaders(headers);
+
+    expect(headers.getAll('x-test-header')).to.deep.equal(['value1', 'value2']);
+  });
+
   it('appends entries onto a header, regardless of casing', function() {
     var headers = new FastBootHeaders();
 
@@ -149,4 +158,3 @@ describe('FastBootHeaders', function() {
     expect(entriesIterator.next()).to.deep.equal({ value: undefined, done: true });
   });
 });
-


### PR DESCRIPTION
When I don't supply the express response in the visit options, everything works fine, but when I do supply it:

``` js
app.visit(url, {
  response: res
})
```

The headers parsing fails because sometimes the header values are already arrays and don't have the split function. A sample while debugging:

```
// values masked...
debug> exec headers
{ 'set-cookie': 
   [ 'ident=14xxxxxxxxx24; Max-Age=1800; Doma... (length: 160)',
     'session=0xxxxxxxxD; Domain=test.com; Path=/;... (length: 89)' ],
  'x-session-id': '5xxxxxxxxx4',
  'x-registration-id': '8xxxxxxx4',
  'x-appserver-id': 'test',
  token: 'eyJhbGciOiJIUzxxxxxxxxxxxxxxxxxRDVGQkR... (length: 1636)' }
```

I don't yet know if this is an issue only I would have for some reason, or it will start turning up in other apps.
