### PR TITLE
Refactor Fastboot's visit API to take additional options

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "fs-promise": "^0.5.0",
     "mocha": "^2.4.5",
     "mocha-jshint": "^2.3.1",
-    "request-promise": "^2.0.1",
     "temp": "^0.8.3"
   }
 }

--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -6,11 +6,17 @@ var FastBootResponse = require('./fastboot-response');
  * A class that encapsulates information about the
  * current HTTP request from FastBoot. This is injected
  * on to the FastBoot service.
+ *
+ * @param {ClientRequest} the incoming request object
+ * @param {ClientResponse} the response object
+ * @param {Object} additional options passed to fastboot info
+ * @param {Array} [options.hostWhitelist] expected hosts in your application
+ * @param {Object} [options.metaData] per request meta data
  */
-function FastBootInfo(request, response, options = {}) {
-  const { hostWhitelist, metadata } = options;
+function FastBootInfo(request, response, options) {
 
   this.deferredPromise = RSVP.resolve();
+  let { hostWhitelist, metadata } = options;
   if (request) {
     this.request = new FastBootRequest(request, hostWhitelist);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,10 @@ class FastBoot {
    * @param {Object} options
    * @param {Boolean} [options.resilient] whether to reject the returned promise if there is an error during rendering. Overrides the instance's `resilient` setting
    * @param {string} [options.html] the HTML document to insert the rendered app into. Uses the built app's index.html by default.
+   * @param {Object} [options.metadata] per request meta data that need to be exposed in the app.
+   * @param {Boolean} [options.shouldRender] whether the app should do rendering or not. If set to false, it puts the app in routing-only.
+   * @param {Boolean} [options.disableShoebox] whether we should send the API data in the shoebox. If set to false, it will not send the API data used for rendering the app on server side in the index.html.
+   * @param {Integer} [options.destroyAppInstanceInMs] whether to destroy the instance in the given number of ms. This is a failure mechanism to not wedge the Node process (See: https://github.com/ember-fastboot/fastboot/issues/90)
    * @returns {Promise<Result>} result
    */
   visit(path, options) {

--- a/src/result.js
+++ b/src/result.js
@@ -11,6 +11,7 @@ const HTMLSerializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 class Result {
   constructor(options) {
     this.instanceBooted = false;
+    this.instanceDestroyed = false;
     this._doc = options.doc;
     this._html = options.html;
     this._fastbootInfo = options.fastbootInfo;
@@ -43,6 +44,18 @@ class Result {
     }
 
     return Promise.resolve(insertIntoIndexHTML(this._html, this._head, this._body));
+  }
+
+  /**
+   * Returns the serialized representation of DOM HEAD and DOM BODY
+   *
+   * @returns {Object} serialized version of DOM
+   */
+  domContents() {
+    return {
+      head: this._head,
+      body: this._body
+    };
   }
 
   /**

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -9,7 +9,10 @@ describe("FastBootInfo", function() {
   var response;
   var request;
   var fastbootInfo;
-  var metadata = { foo: 'bar' };
+  var metadata = {
+    'foo': 'bar',
+    'baz': 'apple'
+  };
 
   beforeEach(function () {
     response = {};
@@ -33,6 +36,7 @@ describe("FastBootInfo", function() {
   it("has a FastBootResponse", function() {
     expect(fastbootInfo.response).to.be.an.instanceOf(FastBootResponse);
   });
+
 
   it("has metadata", function() {
     expect(fastbootInfo.metadata).to.deep.equal(metadata);


### PR DESCRIPTION
## Motivation
Fastboot today renders the application on the server side and exposes an API to serve the base page as well via [fastboot-app-server](https://github.com/ember-fastboot/fastboot-app-server). Various companies may chose to use their own proprietary infrastructure to serve the base page (with doing other things on top of it). While they serve the base page using a different infrastructure, they may want use this fastboot library with serving the  ember app on the server side as is.

This PR adds a bunch of options to the `FastBoot` so that we can use this library can be used as a standalone without needing to serve the base page to the browser using this library. It also now allows apps to be served in "routing-only" mode (aka bigpipe).

## Public API
In order to address the above, following are the additional options exposed via the `visit` method:
- [x] `metaData`: Allows to pass per request meta data (as `metaData`) for every `visit` and exposes it via the fastboot [service](https://github.com/ember-fastboot/ember-cli-fastboot/pull/280). This allows apps to pass in any additional data and use it in the app when routing/rendering on server side. 
- [x] `shouldRender`: Passes `shouldRender` option via `visit` which should allow the app to be executed in ["routing-only"](https://github.com/emberjs/ember.js/blob/aeeddf7c00b42a340494465252481b5414d87009/packages/ember-application/lib/system/application-instance.js#L378) mode. This can allow an app to disable rendering on per request basis and use bigpipe as we do at LinkedIn. It is more performant than a full render if you only plan to use the shoebox from server side rendered app.
- [x] `disableShoebox`: Allows apps to not send API data in the shoebox. Apps may be sending API data via different means.
- [x] `destroyAppInstanceInMs`: Allows apps to set an time in ms after which an app instance will forcefully be destroyed. This is a more for a failure mechanism and fixes this [issue](https://github.com/ember-fastboot/fastboot/issues/90)
- [x] `sandbox`: Creating a fastboot instance now allows you to pass a custom sandbox class. See [PR](https://github.com/ember-fastboot/fastboot/pull/92)
- [x] `addOrOverrideSandboxGlobals`: Allows to pass a object of extra variables and values that will be exposed in the sandbox. This could be very infra specific. See [PR](https://github.com/ember-fastboot/fastboot/pull/92)
- [x] Expose `domContents` method from the result object. This will allow an app using a different infrastructure to read this library and get the data of the rendered route. 

## TODO
- [ ] Update the fastboot-website with all of the above public API
- [ ] Update fastboot README.md with this API

## Notes
Once this PR is merged we need to close the following issues/ merge these PRs in order for an app to use any infrastructure to serve the base page and still use server side rendering perfomantly: 
1. We need the parallel PR to this to be merged. The PR is [here](https://github.com/ember-fastboot/ember-cli-fastboot/pull/280).
2. We need to fix the fastboot build performance issues. The related RFC in `ember-cli` is [here](https://github.com/ember-cli/ember-cli/issues/6350).
3. We need to expose an API during build time to allow addons to add other assets to be loaded in fastboot. This issue is being tracked [here](https://github.com/ember-fastboot/ember-cli-fastboot/issues/270).
4. We need the sandbox PR to also be merged. See [here](https://github.com/ember-fastboot/fastboot/pull/92)

Once the above issues are fixed in addition to this PR, at LinkedIn we will be able to simply use:
```javascript
  var fastbootServer = new FastbootServer({
     distPath: '/foo',
     sandbox: <mysandboxclass>,
     addOrOverrideSandboxGlobals: {...}
  });
  fastbootServer.visit(route, {
     shouldRender: false,
     metaData: {...},
     request: {
       headers: {...}
     },
     disableShoebox: false,
     destroyAppInstanceInMs: <some number>
  });
```
This will allow us to remove usage of all private APIs that will be initially used from this library.

cc: @tomdale @arjansingh @danmcclain @kristoferbaxter @ryanone @masonwan @melmerp @chadhietala