### PR TITLE
Set the entry point to the built cjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fastboot",
   "version": "1.0.0-rc.1",
   "description": "Library for rendering Ember apps in node.js",
-  "main": "src/index.js",
+  "main": "dist/cjs/index.js",
   "scripts": {
     "test": "mocha",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
The files in `dist/` was never loaded and it blows up on node 4.2:

```
$ node fastboot-app-server.js
/Users/kitsunde/Development/ember-app-server-404/node_modules/fastboot/src/fastboot-info.js:19
  let { hostWhitelist, metadata } = options;
```

This follow the instructions on https://github.com/monegraph/broccoli-module-alchemist and sets the entry point to the dist file. Further the reason why it was working under travis is probably because of `alchemistRequire` here https://github.com/ember-fastboot/fastboot/blob/master/test/fastboot-test.js#L8

Needed to resolve: https://github.com/ember-fastboot/fastboot-app-server/issues/38