### PR TITLE
Remove Node 0.12 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "stable"
   - "4"
+  - "6"
 
 env:
   - CXX=g++-4.8 WORKER_COUNT=2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FastBoot Changelog
 
+### 1.0.0-rc.3
+
+* Remove Node 0.12 support.
+
 ### 1.0.0-rc.2
 
 * Set the entry point to the built cjs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.2",
   "description": "Library for rendering Ember apps in node.js",
   "main": "dist/cjs/index.js",
   "scripts": {
@@ -15,6 +15,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ember-fastboot/fastboot.git"
+  },
+  "engines": {
+    "node": ">= 4.0.0"
   },
   "keywords": [
     "ember",


### PR DESCRIPTION
@tomdale @danmcclain I removed Node 0.12 support and updated the versions and the changelog.

I did not remove alchemist because I was not sure if we were still keeping it for other reasons. Let me know if we need to remove it and i'll update accordingly.