### PR TITLE
Drop broccoli-alchemist-install plugin

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,5 +1,0 @@
-var alchemist = require('broccoli-module-alchemist');
-
-module.exports = alchemist({
-  targets: ['cjs']
-});

--- a/package.json
+++ b/package.json
@@ -2,14 +2,10 @@
   "name": "fastboot",
   "version": "1.0.0-rc.2",
   "description": "Library for rendering Ember apps in node.js",
-  "main": "dist/cjs/index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "mocha",
-    "prebuild": "rimraf dist",
-    "build": "broccoli build dist",
     "preversion": "npm test",
-    "prepublish": "npm run build",
-    "postinstall": "broccoli-module-alchemist-install",
     "postversion": "git push origin master --tags"
   },
   "repository": {
@@ -30,7 +26,6 @@
   },
   "homepage": "https://github.com/ember-fastboot/fastboot#readme",
   "dependencies": {
-    "broccoli-module-alchemist-install": "^0.1.1",
     "chalk": "^0.5.1",
     "cookie": "^0.2.3",
     "debug": "^2.1.0",
@@ -47,9 +42,6 @@
   "devDependencies": {
     "babel-core": "^6.10.4",
     "babel-preset-es2015": "^6.9.0",
-    "broccoli": "^0.16.9",
-    "broccoli-cli": "^1.0.0",
-    "broccoli-module-alchemist": "^0.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "fs-promise": "^0.5.0",

--- a/test/fastboot-headers-test.js
+++ b/test/fastboot-headers-test.js
@@ -2,8 +2,7 @@
 
 var expect = require('chai').expect;
 var path = require('path');
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var FastBootHeaders = alchemistRequire('fastboot-headers.js');
+var FastBootHeaders = require('./../src/fastboot-headers.js');
 
 describe('FastBootHeaders', function() {
   it('returns an array from getAll when header value is string', function() {
@@ -148,4 +147,3 @@ describe('FastBootHeaders', function() {
     expect(entriesIterator.next()).to.deep.equal({ value: undefined, done: true });
   });
 });
-

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -1,9 +1,8 @@
 var expect = require('chai').expect;
 var path = require('path');
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var FastBootInfo = alchemistRequire('fastboot-info.js');
-var FastBootResponse = alchemistRequire('fastboot-response.js');
-var FastBootRequest = alchemistRequire('fastboot-request.js');
+var FastBootInfo = require('./../src/fastboot-info.js');
+var FastBootResponse = require('./../src/fastboot-response.js');
+var FastBootRequest = require('./../src/fastboot-request.js');
 
 describe("FastBootInfo", function() {
   var response;

--- a/test/fastboot-request-test.js
+++ b/test/fastboot-request-test.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
 var path = require('path');
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var FastBootRequest = alchemistRequire('fastboot-request.js');
+var FastBootRequest = require('./../src/fastboot-request.js');
 
 describe("FastBootRequest", function() {
   it("throws an exception if no hostWhitelist is provided", function() {

--- a/test/fastboot-response-test.js
+++ b/test/fastboot-response-test.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var FastBootHeaders = alchemistRequire('fastboot-headers.js');
-var FastBootResponse = alchemistRequire('fastboot-response.js');
+var FastBootHeaders = require('./../src/fastboot-headers.js');
+var FastBootResponse = require('./../src/fastboot-response.js');
 
 describe("FastBootResponse", function() {
   var fastBootResponse;

--- a/test/fastboot-shoebox-test.js
+++ b/test/fastboot-shoebox-test.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const expect         = require('chai').expect;
-const fs             = require('fs');
-const path           = require('path');
-const fixture        = require('./helpers/fixture-path');
-const alchemistRequire = require('broccoli-module-alchemist/require');
-const FastBoot       = alchemistRequire('index');
+const expect = require('chai').expect;
+const fs = require('fs');
+const path = require('path');
+const fixture = require('./helpers/fixture-path');
+const FastBoot = require('./../src/index');
 
 describe("FastBootShoebox", function() {
 

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const expect           = require('chai').expect;
-const fs               = require('fs');
-const path             = require('path');
-const fixture          = require('./helpers/fixture-path');
-const alchemistRequire = require('broccoli-module-alchemist/require');
-const FastBoot         = alchemistRequire('index');
-const CustomSandbox    = require('./fixtures/custom-sandbox/custom-sandbox');
+const expect = require('chai').expect;
+const fs = require('fs');
+const path = require('path');
+const fixture = require('./helpers/fixture-path');
+const FastBoot = require('./../src/index');
+const CustomSandbox = require('./fixtures/custom-sandbox/custom-sandbox');
 
 describe("FastBoot", function() {
   it("throws an exception if no distPath is provided", function() {

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -1,7 +1,6 @@
 var express = require('express');
 var RSVP = require('rsvp');
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var FastBoot = alchemistRequire('index');
+var FastBoot = require('./../src/index');
 
 function TestHTTPServer(options) {
   options = options || {};

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
-var alchemistRequire = require('broccoli-module-alchemist/require');
-var Result = alchemistRequire('result.js');
-var FastBootInfo = alchemistRequire('fastboot-info.js');
+var Result = require('./../src/result.js');
+var FastBootInfo = require('./../src/fastboot-info.js');
 var SimpleDOM = require('simple-dom');
 
 describe('Result', function() {


### PR DESCRIPTION
We have dropped Node 0.12 support, therefore there is no need to have this plugin and add time to the npm install step.

cc: @tomdale @rwjblue @danmcclain @arjansingh 