### PR TITLE
Fix use of ES6 features not available in Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "source-map-support": "^0.4.0"
   },
   "devDependencies": {
-    "babel-core": "^6.10.4",
-    "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "fs-promise": "^0.5.0",

--- a/src/fastboot-headers.js
+++ b/src/fastboot-headers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Partially implements Headers from the Fetch API
 // https://developer.mozilla.org/en-US/docs/Web/API/Headers
 function FastBootHeaders(headers) {

--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var RSVP = require('rsvp');
 var FastBootRequest = require('./fastboot-request');
 var FastBootResponse = require('./fastboot-response');
@@ -16,7 +18,8 @@ var FastBootResponse = require('./fastboot-response');
 function FastBootInfo(request, response, options) {
 
   this.deferredPromise = RSVP.resolve();
-  let { hostWhitelist, metadata } = options;
+  let hostWhitelist = options.hostWhitelist;
+  let metadata = options.metadata;
   if (request) {
     this.request = new FastBootRequest(request, hostWhitelist);
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --require test/support/common
---compilers js:babel-core/register
 --timeout 10000


### PR DESCRIPTION
**tl;dr the latest release is broken in Node 4**

I got this stack trace in Travis when running FastBoot tests:
```
  ember-cli-addon-tests Unexpected token {
  ember-cli-addon-tests SyntaxError: Unexpected token {
  ember-cli-addon-tests     at exports.runInThisContext (vm.js:53:16)
  ember-cli-addon-tests     at Module._compile (module.js:373:25)
  ember-cli-addon-tests     at Object.Module._extensions..js (module.js:416:10)
  ember-cli-addon-tests     at Module.load (module.js:343:32)
  ember-cli-addon-tests     at Function.Module._load (module.js:300:12)
  ember-cli-addon-tests     at Module.require (module.js:353:17)
  ember-cli-addon-tests     at require (internal/module.js:12:17)
  ember-cli-addon-tests     at Object.<anonymous> (/tmp/d-117111-3490-141h8zz/pristine/node_modules/fastboot/src/ember-app.js:13:22)
```

This came from the use of object destructuring [here](https://github.com/ember-fastboot/fastboot/blob/master/src/fastboot-info.js#L19), which node 4 does not support. Also there were some cases of `let`/`const` used without 'use strict'.

The problem was probably uncovered with the removal of transpilation in https://github.com/ember-fastboot/fastboot/pull/121. Interestingly Travis did not catch it, because it still used Babel, probably by mistake: https://github.com/ember-fastboot/fastboot/blob/master/test/mocha.opts#L2

This PR should fix these things. 

I assume that the removal of transpilation (the alchemist thing) is still wanted, so ES6 features not supported in node 4 may not be used. In case you prefer to use the latest ES6 and bring back transpilation, I can try to change this PR accordingly. But there were so few changes required, I think it should be ok how it is now!? /cc @tomdale @rwjblue @danmcclain @arjansingh