### PR TITLE
Make sure the same sandbox APIs are used during reloads

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -60,7 +60,6 @@ class EmberApp {
    * @param {Object} [sandboxGlobals={}] any additional variables to expose in the sandbox or override existing in the sandbox
    */
   buildSandbox(distPath, sandboxClass, sandboxGlobals) {
-    let Sandbox = sandboxClass || require('./vm-sandbox');
     let sandboxRequire = this.buildWhitelistedRequire(this.moduleWhitelist, distPath);
     let config = this.appConfig;
     function appConfig() {
@@ -81,7 +80,7 @@ class EmberApp {
       }
     }
 
-    return new Sandbox({
+    return new sandboxClass({
       globals: globals
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class FastBoot {
     options = options || {};
 
     this.distPath = options.distPath;
-    this.sandbox = options.sandbox;
+    this.sandbox = options.sandbox || require('./vm-sandbox');
     this.sandboxGlobals = options.sandboxGlobals || {};
     this.resilient = !!options.resilient || false;
 
@@ -91,11 +91,14 @@ class FastBoot {
       this._app.destroy();
     }
 
-    this._buildEmberApp(options ? options.distPath : null);
+    options = options || {};
+    this._buildEmberApp(options.distPath || null);
   }
 
   _buildEmberApp(distPath, sandbox, sandboxGlobals) {
     distPath = distPath || this.distPath;
+    sandbox = sandbox || this.sandbox;
+    sandboxGlobals = sandboxGlobals || this.sandboxGlobals;
 
     if (!distPath) {
       throw new Error('You must instantiate FastBoot with a distPath ' +

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -202,6 +202,62 @@ describe("FastBoot", function() {
     }
   });
 
+  it("can reload the app using the same sandboxGlobals", function() {
+    var fastboot = new FastBoot({
+      distPath: fixture('basic-app'),
+      sandboxGlobals: {
+        foo: 5,
+        najax: 'undefined',
+        myVar: 'undefined'
+      }
+    });
+
+    return fastboot.visit('/')
+      .then(r => r.html())
+      .then(html => expect(html).to.match(/Welcome to Ember/))
+      .then(hotReloadApp)
+      .then(() => fastboot.visit('/foo'))
+      .then(r => r.html())
+      .then((html) => {
+        expect(html).to.match(/foo from sandbox: 5/);
+        expect(html).to.match(/najax in sandbox: undefined/);
+      });
+
+    function hotReloadApp() {
+      fastboot.reload({
+        distPath: fixture('custom-sandbox')
+      });
+    }
+  });
+
+  it("can reload the app using the same sandbox class", function() {
+    var fastboot = new FastBoot({
+      distPath: fixture('basic-app'),
+      sandbox: CustomSandbox,
+      sandboxGlobals: {
+        myVar: 2,
+        foo: 'undefined',
+        najax: 'undefined'
+      }
+    });
+
+    return fastboot.visit('/')
+      .then(r => r.html())
+      .then(html => expect(html).to.match(/Welcome to Ember/))
+      .then(hotReloadApp)
+      .then(() => fastboot.visit('/foo'))
+      .then(r => r.html())
+      .then((html) => {
+        expect(html).to.match(/myVar in sandbox: 2/);
+      });
+
+    function hotReloadApp() {
+      fastboot.reload({
+        distPath: fixture('custom-sandbox')
+      });
+    }
+  });
+
   it("reads the config from package.json", function() {
     var fastboot = new FastBoot({
       distPath: fixture('config-app')


### PR DESCRIPTION
When reloading the app (for example during rebuilds), we need to make sure we use the same `sandbox` class and the same set of `sandboxGlobals` that were used to initial creation of AppInstance.

Discovered this while working on the serve refactor (when introducing fastboot live reload in new serve refactor) in ember-cli-fastboot.

cc: @rwjblue @tomdale @danmcclain 