### PR TITLE
Escape '$' as '$$$' due to `String.replace()` special patterns 💰

### DIFF
--- a/src/result.js
+++ b/src/result.js
@@ -112,11 +112,19 @@ class Result {
   }
 }
 
+/**
+ * `String.replace()` converts '$$' to '$', so we must escape each '$' as '$$';
+ * but because we’re using `String.replace()` to do it, we must use '$$$'!
+ */
+function escapeForStringReplace(string) {
+  return string.replace(/\$/g, '$$$');
+}
+
 function insertIntoIndexHTML(html, head, body) {
-  html = html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
+  html = html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", escapeForStringReplace(body));
 
   if (head) {
-    html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", head);
+    html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", escapeForStringReplace(head));
   }
 
   return html;

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -81,5 +81,23 @@ describe('Result', function() {
         });
       });
     });
+
+    describe('when the document has special-case content', function () {
+      var BODY = '<h1>A special response document: $$</h1>';
+
+      beforeEach(function () {
+        doc.body.appendChild(doc.createRawHTMLSection(BODY));
+
+        result._fastbootInfo.response.statusCode = 418;
+        result._finalize();
+      });
+
+      it('it should handle \'$$\' correctly (due to `String.replace()` gotcha)', function () {
+        return result.html()
+        .then(function (result) {
+          expect(result).to.include(BODY);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
We found that `$$` in our content ("A$$") was being replaced with `$` ("A$") in production. Believe it or not, this is due to Javascript’s `String.replace()`:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace