### PR TITLE
Upgrade to najax version 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-cluster": "0.0.4",
     "glob": "^4.0.5",
     "minimist": "^1.2.0",
-    "najax": "^1.0.1",
+    "najax": "^1.0.2",
     "rsvp": "^3.0.16",
     "simple-dom": "^0.3.0",
     "source-map-support": "^0.4.0"


### PR DESCRIPTION
The upgrade contains an important fix for catching errors when an
assumed json endpoint returns html.  This can happen when the gateway
times out.

See: https://github.com/najaxjs/najax/pull/56