### PR TITLE
Configurable element that shoebox is appended to

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -39,13 +39,11 @@ class EmberApp {
     this.moduleWhitelist = config.moduleWhitelist;
     this.hostWhitelist = config.hostWhitelist;
     this.appConfig = config.appConfig;
+    this.shoeboxAppendTo = config.shoeboxAppendTo;
 
     if (process.env.APP_CONFIG) {
       this.appConfig = JSON.parse(process.env.APP_CONFIG);
     }
-
-    // FIXME ember-cli-fastboot should add it to dist/package.json
-    this.shoeboxAppendTo = this.appConfig.fastboot.shoeboxAppendTo;
 
     this.html = fs.readFileSync(config.htmlFile, 'utf8');
 
@@ -393,7 +391,8 @@ class EmberApp {
       htmlFile: path.join(distPath, manifest.htmlFile),
       moduleWhitelist: pkg.fastboot.moduleWhitelist,
       hostWhitelist: pkg.fastboot.hostWhitelist,
-      appConfig: pkg.fastboot.appConfig
+      appConfig: pkg.fastboot.appConfig,
+      shoeboxAppendTo: pkg.fastboot.shoeboxAppendTo
     };
   }
 

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -44,6 +44,9 @@ class EmberApp {
       this.appConfig = JSON.parse(process.env.APP_CONFIG);
     }
 
+    // FIXME ember-cli-fastboot should add it to dist/package.json
+    this.shoeboxAppendTo = this.appConfig.fastboot.shoeboxAppendTo;
+
     this.html = fs.readFileSync(config.htmlFile, 'utf8');
 
     this.sandbox = this.buildSandbox(distPath, options.sandbox, options.sandboxGlobals);
@@ -275,6 +278,7 @@ class EmberApp {
     let html = options.html || this.html;
     let disableShoebox = options.disableShoebox || false;
     let destroyAppInstanceInMs = options.destroyAppInstanceInMs;
+    let shoeboxAppendTo = this.shoeboxAppendTo;
 
     let shouldRender = (options.shouldRender !== undefined) ? options.shouldRender : true;
     let bootOptions = buildBootOptions(shouldRender);
@@ -313,7 +317,7 @@ class EmberApp {
       .then(() => {
         if (!disableShoebox) {
           // if shoebox is not disabled, then create the shoebox and send API data
-          createShoebox(doc, fastbootInfo);
+          createShoebox(doc, fastbootInfo, shoeboxAppendTo);
         }
       })
       .catch(error => result.error = error)
@@ -441,9 +445,11 @@ function waitForApp(instance) {
  * parse the specific item at the time it is needed instead of everything
  * all at once.
  */
-function createShoebox(doc, fastbootInfo) {
+function createShoebox(doc, fastbootInfo, shoeboxAppendTo) {
   let shoebox = fastbootInfo.shoebox;
   if (!shoebox) { return RSVP.resolve(); }
+
+  let appendTo = shoeboxAppendTo || 'body';
 
   for (let key in shoebox) {
     if (!shoebox.hasOwnProperty(key)) { continue; }
@@ -458,7 +464,7 @@ function createShoebox(doc, fastbootInfo) {
     scriptEl.setAttribute('type', 'fastboot/shoebox');
     scriptEl.setAttribute('id', `shoebox-${key}`);
     scriptEl.appendChild(scriptText);
-    doc.body.appendChild(scriptEl);
+    doc[appendTo].appendChild(scriptEl);
   }
 
   return RSVP.resolve();

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -38,7 +38,7 @@ class EmberApp {
     this.moduleWhitelist = config.moduleWhitelist;
     this.hostWhitelist = config.hostWhitelist;
     this.appConfig = config.appConfig;
-    this.shoeboxAppendTo = config.shoeboxAppendTo;
+    this.shoeboxAppendTo = this.appConfig.fastboot.shoeboxAppendTo;
 
     if (process.env.APP_CONFIG) {
       this.appConfig = JSON.parse(process.env.APP_CONFIG);


### PR DESCRIPTION
I need FastBoot to put the shoebox in the head element, instead of the body. This PR adds an option to override the element using `config/environment.js`:
```
var ENV = {
  fastboot: {
    shoeboxAppendTo: 'head'
  }
}
```

If this look good, I'm going to update [ember-cli-fastboot](https://github.com/ember-fastboot/ember-cli-fastboot/blob/3d1f3f372765df1dad23aa79087e486868b2d59f/lib/broccoli/fastboot-config.js#L168-L179) to add this option to `dist/package.json` instead of accessing `appConfig` directly and will add some tests (and fix the failing ones).

Why I need it in the head? Because we have tracking scripts in the head that have to run before Ember starts and which depend on the data we store in the shoebox. The only other way I see to make it work is to avoid using shoebox and store the data in global variables. It's how we did it before FastBoot and I would prefer to not go this way.