### PR TITLE
Fix deprecated minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "exists-sync": "0.0.3",
     "express": "^4.13.3",
     "express-cluster": "0.0.4",
-    "glob": "^4.0.5",
+    "glob": "^7.1.1",
     "minimist": "^1.2.0",
     "najax": "^1.0.2",
     "rsvp": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "exists-sync": "0.0.3",
     "express": "^4.13.3",
     "express-cluster": "0.0.4",
-    "glob": "^7.1.1",
     "minimist": "^1.2.0",
     "najax": "^1.0.2",
     "rsvp": "^3.0.16",


### PR DESCRIPTION
Hey,
In this PR I upgraded `glob` to the latest version which depends on `minimatch ^3.0.2`.
Thanks to this, it will fix a deprecation:
> Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue