### PR TITLE
remove `.hasOwnProperty` check for shoebox keys

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -430,11 +430,14 @@ function waitForApp(instance) {
  * parse the specific item at the time it is needed instead of everything
  * all at once.
  */
+const hasOwnProperty = Object.prototype.hasOwnProperty; // jshint ignore:line
+
 function createShoebox(doc, fastbootInfo) {
   let shoebox = fastbootInfo.shoebox;
   if (!shoebox) { return; }
 
   for (let key in shoebox) {
+    if (!hasOwnProperty.call(shoebox, key)) { continue; } // TODO: remove this later #144, ember-fastboot/ember-cli-fastboot/pull/417
     let value = shoebox[key];
     let textValue = JSON.stringify(value);
     textValue = escapeJSONString(textValue);

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -435,8 +435,6 @@ function createShoebox(doc, fastbootInfo) {
   if (!shoebox) { return; }
 
   for (let key in shoebox) {
-    if (!shoebox.hasOwnProperty(key)) { continue; }
-
     let value = shoebox[key];
     let textValue = JSON.stringify(value);
     textValue = escapeJSONString(textValue);


### PR DESCRIPTION
no need to check for `.hasOwnProperty` if shoebox has empty proto https://github.com/ember-fastboot/ember-cli-fastboot/pull/417