### PR TITLE
moved app instance destroy logic to `result._destroyAppInstance`

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -266,7 +266,7 @@ class EmberApp {
     let res = options.response;
     let html = options.html || this.html;
     let disableShoebox = options.disableShoebox || false;
-    let destroyAppInstanceInMs = options.destroyAppInstanceInMs;
+    let destroyAppInstanceInMs = parseInt(options.destroyAppInstanceInMs, 10);
 
     let shouldRender = (options.shouldRender !== undefined) ? options.shouldRender : true;
     let bootOptions = buildBootOptions(shouldRender);
@@ -285,23 +285,17 @@ class EmberApp {
     });
 
     let destroyAppInstanceTimer;
-    if (parseInt(destroyAppInstanceInMs, 10) > 0) {
+    if (destroyAppInstanceInMs > 0) {
       // start a timer to destroy the appInstance forcefully in the given ms.
       // This is a failure mechanism so that node process doesn't get wedged if the `visit` never completes.
       destroyAppInstanceTimer = setTimeout(function() {
-        if (instance && !result.instanceDestroyed) {
-          result.instanceDestroyed = true;
+        if (result._destroyAppInstance()) {
           result.error = new Error('App instance was forcefully destroyed in ' + destroyAppInstanceInMs + 'ms');
-          instance.destroy();
         }
       }, destroyAppInstanceInMs);
     }
 
-    let instance;
     return this.visitRoute(path, fastbootInfo, bootOptions, result)
-      .then(appInstance => {
-        instance = appInstance;
-      })
       .then(() => {
         if (!disableShoebox) {
           // if shoebox is not disabled, then create the shoebox and send API data
@@ -311,10 +305,7 @@ class EmberApp {
       .catch(error => result.error = error)
       .then(() => result._finalize())
       .finally(() => {
-        if (instance && !result.instanceDestroyed) {
-          result.instanceDestroyed = true;
-          instance.destroy();
-
+        if (result._destroyAppInstance()) {
           if (destroyAppInstanceTimer) {
             clearTimeout(destroyAppInstanceTimer);
           }

--- a/src/result.js
+++ b/src/result.js
@@ -11,7 +11,7 @@ const HTMLSerializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 class Result {
   constructor(options) {
     this.instanceBooted = false;
-    this.instanceDestroyed = false;
+    this._instanceDestroyed = false;
     this._doc = options.doc;
     this._html = options.html;
     this._fastbootInfo = options.fastbootInfo;
@@ -95,6 +95,15 @@ class Result {
       this.headers = response.headers;
       this.statusCode = response.statusCode;
     }
+  }
+
+  _destroyAppInstance() {
+    if (this.instance && !this._instanceDestroyed) {
+      this._instanceDestroyed = true;
+      this.instance.destroy();
+      return true;
+    }
+    return false;
   }
 
   _finalizeHTML() {


### PR DESCRIPTION
`result._destroyAppInstance` encapsulates all destroy logic which was spread in `visit` method