### PR TITLE
Assert require sandbox object in EmberApp constructor

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -26,10 +26,14 @@ class EmberApp {
    * Create a new EmberApp.
    * @param {Object} options
    * @param {string} options.distPath - path to the built Ember application
-   * @param {Sandbox} [options.sandbox=VMSandbox] - sandbox to use
+   * @param {Sandbox} options.sandbox=VMSandbox - sandbox to use
    * @param {Object} [options.sandboxGlobals] - sandbox variables that can be added or used for overrides in the sandbox.
    */
   constructor(options) {
+    if (typeof options.sandbox === 'undefined' || !(options.sandbox instanceof Object)) {
+      throw new Error('Sandbox object is required option to construct EmberApp object');
+    }
+
     let distPath = path.resolve(options.distPath);
     let config = this.readPackageJSON(distPath);
 

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -38,6 +38,18 @@ describe("FastBoot", function() {
     expect(fn).to.throw(/An incompatible version between `ember-cli-fastboot` and `fastboot` was found/);
   });
 
+  it('throws an error when sandbox object is not valid', function() {
+    var distPath = fixture('higher-schema-version');
+    var fn = function() {
+      return new FastBoot({
+        distPath: distPath,
+        sandbox: 10
+      });
+    };
+
+    expect(fn).to.throw(/Sandbox object is required option to construct EmberApp object/);
+  });
+
   it("doesn't throw an exception if a package.json is provided", function() {
     var distPath = fixture('empty-package-json');
     var fn = function() {


### PR DESCRIPTION
Due to the API change in this commit  https://github.com/ember-fastboot/fastboot/commit/b155d0f9cbe7d2079b65a7819921394975afcc8f, Sandbox object become required argument to construct EmberApp. Add obvious assertion message for easy debugging.