### PR TITLE
[WIP] Allow AMP File to be used based on toggle

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -44,6 +44,7 @@ class EmberApp {
     }
 
     this.html = fs.readFileSync(config.htmlFile, 'utf8');
+    this.amp = this.htmlFile !== this.ampFile ? fs.readFileSync(config.ampFile, 'utf8') : this.html;
 
     this.sandbox = this.buildSandbox(distPath, options.sandbox, options.sandboxGlobals);
     this.app = this.retrieveSandboxedApp();
@@ -267,8 +268,8 @@ class EmberApp {
   visit(path, options) {
     let req = options.request;
     let res = options.response;
-    let html = options.html || this.html;
     let disableShoebox = options.disableShoebox || false;
+     let html = options.html || options.ampMode ? this.amp : this.html;
     let destroyAppInstanceInMs = parseInt(options.destroyAppInstanceInMs, 10);
 
     let shouldRender = (options.shouldRender !== undefined) ? options.shouldRender : true;
@@ -370,6 +371,7 @@ class EmberApp {
     return {
       appFiles: appFiles,
       vendorFiles: vendorFiles,
+      ampFile: path.join(distPath, manifest.ampFile),
       htmlFile: path.join(distPath, manifest.htmlFile),
       moduleWhitelist: pkg.fastboot.moduleWhitelist,
       hostWhitelist: pkg.fastboot.hostWhitelist,

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -44,7 +44,7 @@ class EmberApp {
     }
 
     this.html = fs.readFileSync(config.htmlFile, 'utf8');
-    this.amp = this.htmlFile !== this.ampFile ? fs.readFileSync(config.ampFile, 'utf8') : this.html;
+    this.amp = config.htmlFile !== config.ampFile ? fs.readFileSync(config.ampFile, 'utf8') : this.html;
 
     this.sandbox = this.buildSandbox(distPath, options.sandbox, options.sandboxGlobals);
     this.app = this.retrieveSandboxedApp();

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,13 @@ class FastBoot {
       resilient = this.resilient;
     }
 
+    // Not sure what to make cause the switch
+    // As ember-cli-fastboot and fastboot-app-server
+    // Do not allow you to pass options down to the Fastboot Class
+    if (path.includes('?ampMode=true')) {
+      options.ampMode = true;
+    }
+
     return this._app.visit(path, options)
       .then(result => {
         if (!resilient && result.error) {


### PR DESCRIPTION
@kratiahuja 

I was thinking something like this or possibly allow for a map of different HTML files based on a key which could be the path or a regex but this would mean the readFileSync would have to be done on every visit and would not be performant

Corresponding PR In ember-cli-fastboot
https://github.com/ember-fastboot/ember-cli-fastboot/pull/525