### PR TITLE
add API for response chunks

### DIFF
--- a/src/result.js
+++ b/src/result.js
@@ -62,6 +62,10 @@ class Result {
   chunks() {
     return insertIntoIndexHTML(this._html, this._head, this._body, this._bodyAttributes).then((html) => {
       let docParts = html.match(HTML_HEAD_REGEX);
+      if (!docParts || docParts.length === 1) {
+        return [html];
+      }
+
       let head = docParts[1];
       let body = docParts[2];
 

--- a/src/result.js
+++ b/src/result.js
@@ -62,8 +62,12 @@ class Result {
   chunks() {
     return insertIntoIndexHTML(this._html, this._head, this._body, this._bodyAttributes).then((html) => {
       let [, head, body] = html.match(HTML_HEAD_REGEX);
-      let chunks = [head];
 
+      if (!head || !body) {
+        throw new Error('Could not idenfity head and body of the document! Make sure the document is well formed.');
+      }
+
+      let chunks = [head];
       let [plainBody, ...shoeboxes] = body.split(SHOEBOX_TAG_PATTERN);
       chunks.push(plainBody);
       shoeboxes.forEach((shoebox) => {

--- a/src/result.js
+++ b/src/result.js
@@ -61,15 +61,20 @@ class Result {
    */
   chunks() {
     return insertIntoIndexHTML(this._html, this._head, this._body, this._bodyAttributes).then((html) => {
-      let [, head, body] = html.match(HTML_HEAD_REGEX);
+      let docParts = html.match(HTML_HEAD_REGEX);
+      let head = docParts[1];
+      let body = docParts[2];
 
       if (!head || !body) {
         throw new Error('Could not idenfity head and body of the document! Make sure the document is well formed.');
       }
 
       let chunks = [head];
-      let [plainBody, ...shoeboxes] = body.split(SHOEBOX_TAG_PATTERN);
+      let bodyParts = body.split(SHOEBOX_TAG_PATTERN);
+      let plainBody = bodyParts[0];
       chunks.push(plainBody);
+
+      let shoeboxes = bodyParts.splice(1);
       shoeboxes.forEach((shoebox) => {
         chunks.push(`${SHOEBOX_TAG_PATTERN}${shoebox}`);
       });

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -194,6 +194,20 @@ describe("FastBoot", function() {
       });
   });
 
+  it("returns only one chunk if the resilient flag is set", function() {
+    var fastboot = new FastBoot({
+      distPath: fixture('rejected-promise'),
+      resilient: true
+    });
+
+    return fastboot.visit('/')
+      .then(r => r.chunks())
+      .then(chunks => {
+        expect(chunks.length).to.eq(1);
+        expect(chunks[0]).to.match(/<body>/);
+      });
+  });
+
   it("can reload the distPath", function() {
     var fastboot = new FastBoot({
       distPath: fixture('basic-app')

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -134,8 +134,8 @@ describe('Result', function() {
   });
 
   describe('chunks()', function() {
-    let HEAD = '<meta name="foo" content="bar">';
-    let BODY = '<h1>A normal response document</h1>';
+    var HEAD = '<meta name="foo" content="bar">';
+    var BODY = '<h1>A normal response document</h1>';
 
     beforeEach(function() {
       result._fastbootInfo.response.statusCode = 200;

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -143,6 +143,16 @@ describe('Result', function() {
                       <body><!-- EMBER_CLI_FASTBOOT_BODY --></body></html>`;
     });
 
+    it('rejects when the document does not have <head> and/or <body> tags', function() {
+      result._html = `<!-- EMBER_CLI_FASTBOOT_HEAD -->
+                      <!-- EMBER_CLI_FASTBOOT_BODY -->`;
+
+      return result.chunks()
+      .catch(function (err) {
+        return expect(err).to.be.not.null;
+      });
+    });
+
     describe('when there is no shoebox', function() {
       beforeEach(function () {
         doc.head.appendChild(doc.createRawHTMLSection(HEAD));

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -137,12 +137,17 @@ describe('Result', function() {
     let HEAD = '<meta name="foo" content="bar">';
     let BODY = '<h1>A normal response document</h1>';
 
+    beforeEach(function() {
+      result._fastbootInfo.response.statusCode = 200;
+      result._html = `<html><head><!-- EMBER_CLI_FASTBOOT_HEAD --></head>
+                      <body><!-- EMBER_CLI_FASTBOOT_BODY --></body></html>`;
+    });
+
     describe('when there is no shoebox', function() {
       beforeEach(function () {
         doc.head.appendChild(doc.createRawHTMLSection(HEAD));
         doc.body.appendChild(doc.createRawHTMLSection(BODY));
 
-        result._fastbootInfo.response.statusCode = 200;
         result._finalize();
       });
 
@@ -150,8 +155,8 @@ describe('Result', function() {
         return result.chunks()
         .then(function (result) {
           expect(result.length).to.eq(2);
-          expect(result[0]).to.eq('<html><head><meta name="foo" content="bar"></head>');
-          expect(result[1]).to.eq('\n            <body><h1>A normal response document</h1></body></html>');
+          expect(result[0]).to.eq(`<html><head>${HEAD}</head>`);
+          expect(result[1]).to.eq(`\n                      <body>${BODY}</body></html>`);
         });
       });
     });
@@ -162,7 +167,6 @@ describe('Result', function() {
         doc.body.appendChild(doc.createRawHTMLSection(BODY));
         doc.body.appendChild(doc.createRawHTMLSection('<script type="fastboot/shoebox" id="shoebox-something">{ "some": "data" }</script>'));
 
-        result._fastbootInfo.response.statusCode = 200;
         result._finalize();
       });
 
@@ -170,8 +174,8 @@ describe('Result', function() {
         return result.chunks()
         .then(function (result) {
           expect(result.length).to.eq(3);
-          expect(result[0]).to.eq('<html><head><meta name="foo" content="bar"></head>');
-          expect(result[1]).to.eq('\n            <body><h1>A normal response document</h1>');
+          expect(result[0]).to.eq(`<html><head>${HEAD}</head>`);
+          expect(result[1]).to.eq(`\n                      <body>${BODY}`);
           expect(result[2]).to.eq('<script type="fastboot/shoebox" id="shoebox-something">{ "some": "data" }</script></body></html>');
         });
       });
@@ -185,7 +189,6 @@ describe('Result', function() {
         doc.body.appendChild(doc.createRawHTMLSection('<script type="fastboot/shoebox" id="shoebox-something-b">{ "some": "data" }</script>'));
         doc.body.appendChild(doc.createRawHTMLSection('<script type="fastboot/shoebox" id="shoebox-something-c">{ "some": "data" }</script>'));
 
-        result._fastbootInfo.response.statusCode = 200;
         result._finalize();
       });
 
@@ -193,8 +196,8 @@ describe('Result', function() {
         return result.chunks()
         .then(function (result) {
           expect(result.length).to.eq(5);
-          expect(result[0]).to.eq('<html><head><meta name="foo" content="bar"></head>');
-          expect(result[1]).to.eq('\n            <body><h1>A normal response document</h1>');
+          expect(result[0]).to.eq(`<html><head>${HEAD}</head>`);
+          expect(result[1]).to.eq(`\n                      <body>${BODY}`);
           expect(result[2]).to.eq('<script type="fastboot/shoebox" id="shoebox-something-a">{ "some": "data" }</script>');
           expect(result[3]).to.eq('<script type="fastboot/shoebox" id="shoebox-something-b">{ "some": "data" }</script>');
           expect(result[4]).to.eq('<script type="fastboot/shoebox" id="shoebox-something-c">{ "some": "data" }</script></body></html>');


### PR DESCRIPTION
This adds a new method `chunks` to the `Result` class that returns the HTML in chunks:

* if there are no shoeboxes in the document, it returns 2 chunks - one for the header and one for the body
* if there are shoeboxes in the document, it returns n chunks - one for the header, one for the body (except the shoeboxes that are at the bottom of the body) and one for each shoebox

The idea behind this is that this could be used in e.g. https://github.com/ember-fastboot/fastboot-express-middleware to send a streaming response so that big shoeboxes don't delay the whole document.

closes #174 