### PR TITLE
Rehydration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,15 +452,6 @@
         "silent-error": "1.1.0"
       }
     },
-    "ember-cli-version-checker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-      "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-      "dev": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
     "ember-router-generator": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
@@ -471,9 +462,9 @@
       }
     },
     "ember-source": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.16.2.tgz",
-      "integrity": "sha1-68Kc423sPsyA9rGwIhjWPKUEEIg=",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.17.0.tgz",
+      "integrity": "sha1-t4hx3Um9jWQrgBdt9Pr3/X0Fnaw=",
       "dev": true,
       "requires": {
         "broccoli-funnel": "1.2.0",
@@ -485,18 +476,28 @@
         "ember-cli-string-utils": "1.1.0",
         "ember-cli-test-info": "1.0.0",
         "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "1.3.1",
+        "ember-cli-version-checker": "2.1.0",
         "ember-router-generator": "1.2.3",
-        "fs-extra": "4.0.2",
+        "fs-extra": "4.0.3",
         "inflection": "1.12.0",
         "jquery": "3.2.1",
         "resolve": "1.5.0"
       },
       "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.4.1"
+          }
+        },
         "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -1011,9 +1012,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -427,12 +427,14 @@ class EmberApp {
 function buildBootOptions(shouldRender) {
   let doc = new SimpleDOM.Document();
   let rootElement = doc.body;
+  let _renderMode = process.env.EXPERIMENTAL_RENDER_MODE_SERIALIZE ? 'serialize' : undefined;
 
   return {
     isBrowser: false,
     document: doc,
     rootElement,
-    shouldRender
+    shouldRender,
+    _renderMode
   };
 }
 


### PR DESCRIPTION
This is part of an arching plan to introduce Glimmer's
rehydration/serializtion modes to Ember proper.

There are 4 PR's that are all interwoven, of which, this is one.

- [x] Glimmer.js: glimmerjs/glimmer-vm#783 (comment)
- [x] Ember.js: emberjs/ember.js#16227
- [ ] Fastboot: ember-fastboot/fastboot#185
- [ ] EmberCLI Fastboot: ember-fastboot/ember-cli-fastboot#580

In order of need to land they are:

Glimmer.js:
glimmerjs/glimmer-vm#783 (comment)

This resolves a rather intimate API problem.  Glimmer-vm expects a very
specific comment node to exist to know whether or not the rehydration
element builder can do it's job properly.  If it is not found on the
first node from `rootElement` it throws.

In fastboot however we are certain that there will already be existant
elements in the way that will happen before rendered content.

This PR just iterates through the nodes until it finds the expected
comment node.  And only throws if it never finds one.

---

Ember.js:
emberjs/ember.js#16227

This PR modifies the `visit` API to allow a private _renderMode to be
set to either serialize or rehydrate.  In SSR environments the
assumption (as it is here in this fastboot PR) is that we'll set the
visit API to serialize mode which ensures glimmer-vm's serialize element
builder is used to build the API.

The serialize element builder ensures that we have the necessary fidelty
to rehydrate correctly and is mandatory input for rehydration.

---

Fastboot:
ember-fastboot/fastboot#185

This allows enviroment variable to set _renderMode to be used in Visit
API.  Fastboot must send content to browser made with the serialization
element builder to ensure rehydration can be sucessful.

---

EmberCLI Fastboot:
ember-fastboot/ember-cli-fastboot#580

Finally this does the fun part of disabling the current
clear-double-render instance-initializer

We first check to ensure we are in a non-fastboot environment.  Then we
ensure that we can find the expected comment node from glimmer-vm's
serialize element builder.  This ensures that this change will only
effect peoeple who use ember-cli-fastboot with the serialized output
from the currently experimental fastboot setup

Then we ensure `ApplicationInstance#_bootSync` specifies the rehydrate
_renderMode.

This is done in `_bootSync` this way because visit is currently not used
to boot ember applications.  And we must instead set bootOptions this
way instead.

We also remove the markings for `fastboot-body-start` and
`fastboot-body-end` to ensure clear-double render instance-initializer
is never called.