### PR TITLE
Normalize headers to lower case

### DIFF
--- a/src/fastboot-headers.js
+++ b/src/fastboot-headers.js
@@ -17,7 +17,7 @@ class FastBootHeaders {
         value = [value];
       }
 
-      this.headers[header] = value;
+      this.headers[header.toLowerCase()] = value;
     }
   }
 

--- a/test/fastboot-headers-test.js
+++ b/test/fastboot-headers-test.js
@@ -6,6 +6,15 @@ var FastBootHeaders = require('./../src/fastboot-headers.js');
 var Ember = require('ember-source/dist');
 
 describe('FastBootHeaders', function() {
+  it('lower normalizes the headers to lowercase', function() {
+    var headers = {
+      'X-Test-Header': 'value1, value2'
+    };
+    headers = new FastBootHeaders(headers);
+
+    expect(headers.getAll('x-test-header')).to.deep.equal(['value1, value2']);
+  });
+
   it('returns an array from getAll when header value is string', function() {
     var headers = {
       'x-test-header': 'value1, value2'


### PR DESCRIPTION
When accessing a header, fastboot [will lowercase the string](https://github.com/ember-fastboot/fastboot/blob/master/src/fastboot-headers.js#L51-L57) before looking up the header. However, when creating a `FastBootHeaders` object, the casing of the headers [is not changed](https://github.com/ember-fastboot/fastboot/blob/master/src/fastboot-headers.js#L20). This causes a `get` to a capitalized header to fail.

The docs use an example with a capitalized header, `headers.get('X-Request')`, but this will not work due to the case mismatch.

This PR normalizes all headers as lower case strings when creating a `FastBootHeaders` instance.  Now `X-Headers` will be accessible with `get`/`getAll` on `fastboot.request.headers`.