### PR TITLE
Fix require path for on-disk modules

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -121,7 +121,7 @@ class EmberApp {
 
     return function(moduleName) {
       if (whitelist.indexOf(moduleName) > -1) {
-        let nodeModulesPath = path.join(distPath, 'node_modules', moduleName);
+        let nodeModulesPath = path.join(distPath, '..', 'node_modules', moduleName);
 
         if (existsSync(nodeModulesPath)) {
           return require(nodeModulesPath);

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -123,7 +123,7 @@ class EmberApp {
       if (whitelist.indexOf(moduleName) > -1) {
         let nodeModulesPath = path.join(distPath, '..', 'node_modules', moduleName);
 
-        if (existsSync(nodeModulesPath)) {
+        if (existsSync(nodeModulesPath) || existsSync(nodeModulesPath + '.js')) {
           return require(nodeModulesPath);
         } else {
           // If it's not on disk, assume it's a built-in node package


### PR DESCRIPTION
It looks like this path is incorrect (node_modules is not under dist but rather ../dist). It seems to be tripping up the ember-fetch library, see here: https://github.com/ember-cli/ember-fetch/issues/115