### PR TITLE
Remove `rsvp` dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "debug": "^4.1.1",
     "najax": "^1.0.4",
     "resolve": "^1.12.0",
-    "rsvp": "^4.8.0",
     "simple-dom": "^1.4.0",
     "source-map-support": "^0.5.13"
   },

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -1,5 +1,4 @@
 var express = require('express');
-var RSVP = require('rsvp');
 var FastBoot = require('./../src/index');
 
 function TestHTTPServer(options) {
@@ -24,7 +23,7 @@ TestHTTPServer.prototype.start = function() {
 
     app.get('/*', server.middleware());
 
-    return new RSVP.Promise(function(resolve) {
+    return new Promise(function(resolve) {
       var listener = app.listen(options.port, options.host, function() {
         var host = listener.address().address;
         var port = listener.address().port;


### PR DESCRIPTION
Now that we are only supporting Node 8+ we can always leverage async/await for our Node land code and we don't need RSVP directly as a dependency any more.