### PR TITLE
Refactor sandboxGlobals -> buildSandboxGlobals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ let app = new FastBoot({
   distPath: 'path/to/dist',
   // optional boolean flag when set to true does not reject the promise if there are rendering errors (defaults to false)
   resilient: <boolean>,
-  sandboxGlobals: {...} // optional map of key value pairs to expose in the sandbox
+
+  // optional function used to generate the set of global properties available within the sandbox, receives default globals
+  // and is expected to return an object (the default implementation returns the passed in defaults)
+  buildSandboxGlobals(defaultGlobals) {
+    return Object.assign({}, defaultGlobals, {
+      // additional global properties to define within the sandbox
+    });
+  },
 });
 
 app.visit('/photos', options)

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -169,13 +169,15 @@ describe('FastBoot', function() {
       });
   });
 
-  it('can render HTML when sandboxGlobals is provided', function() {
+  it('can render HTML when a custom set of sandbox globals is provided', function() {
     var fastboot = new FastBoot({
       distPath: fixture('custom-sandbox'),
-      sandboxGlobals: {
-        foo: 5,
-        najax: 'undefined',
-        myVar: 'undefined',
+      buildSandboxGlobals(globals) {
+        return Object.assign({}, globals, {
+          foo: 5,
+          najax: 'undefined',
+          myVar: 'undefined',
+        });
       },
     });
 
@@ -256,13 +258,15 @@ describe('FastBoot', function() {
     }
   });
 
-  it('can reload the app using the same sandboxGlobals', function() {
+  it('can reload the app using the same buildSandboxGlobals', function() {
     var fastboot = new FastBoot({
       distPath: fixture('basic-app'),
-      sandboxGlobals: {
-        foo: 5,
-        najax: 'undefined',
-        myVar: 'undefined',
+      buildSandboxGlobals(globals) {
+        return Object.assign({}, globals, {
+          foo: 5,
+          najax: 'undefined',
+          myVar: 'undefined',
+        });
       },
     });
 


### PR DESCRIPTION
This changes the system from providing default set of shared (and therefore mutable) global properties to using a builder function to generate the set of globals to be used _per visit_.

The `buildSandboxGlobals` function will receive the default set of globals that FastBoot creates (currently this is `najax` and `FastBoot`), and whatever the `buildSandboxGlobals` function returns is what will ultimately be used. If `buildSandboxGlobals` is not provided, a default implementation is used (it is essentially `defaultGlobals => defaultGlobals;`).

Closes #239