### PR TITLE
Remove najax from default set of sandbox globals.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "chalk": "^2.4.2",
     "cookie": "^0.4.0",
     "debug": "^4.1.1",
-    "najax": "^1.0.4",
     "resolve": "^1.12.0",
     "simple-dom": "^1.4.0",
     "source-map-support": "^0.5.13"

--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -5,7 +5,6 @@ const vm = require('vm');
 const path = require('path');
 const chalk = require('chalk');
 
-const najax = require('najax');
 const SimpleDOM = require('simple-dom');
 const resolve = require('resolve');
 const debug = require('debug')('fastboot:ember-app');
@@ -92,7 +91,6 @@ class EmberApp {
     }
 
     let defaultGlobals = {
-      najax,
       FastBoot: {
         require: sandboxRequire,
         config: fastbootConfig,

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -175,7 +175,6 @@ describe('FastBoot', function() {
       buildSandboxGlobals(globals) {
         return Object.assign({}, globals, {
           foo: 5,
-          najax: 'undefined',
           myVar: 'undefined',
         });
       },
@@ -186,7 +185,6 @@ describe('FastBoot', function() {
       .then(r => r.html())
       .then(html => {
         expect(html).to.match(/foo from sandbox: 5/);
-        expect(html).to.match(/najax in sandbox: undefined/);
       });
   });
 
@@ -264,7 +262,6 @@ describe('FastBoot', function() {
       buildSandboxGlobals(globals) {
         return Object.assign({}, globals, {
           foo: 5,
-          najax: 'undefined',
           myVar: 'undefined',
         });
       },
@@ -279,7 +276,6 @@ describe('FastBoot', function() {
       .then(r => r.html())
       .then(html => {
         expect(html).to.match(/foo from sandbox: 5/);
-        expect(html).to.match(/najax in sandbox: undefined/);
       });
 
     function hotReloadApp() {

--- a/test/fixtures/custom-sandbox/assets/fastboot-trial.js
+++ b/test/fixtures/custom-sandbox/assets/fastboot-trial.js
@@ -341,7 +341,6 @@ define('fastboot-trial/routes/foo', ['exports', 'ember'], function (exports, _em
       if (this.get('fastboot.isFastBoot')) {
         return {
           foo: foo,
-          najax: najax,
           myVar: myVar
         };
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,11 +1971,6 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-jquery-deferred@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
-  integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2094,11 +2089,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-lodash.defaultsdeep@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
-  integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
 
 lodash.find@^4.6.0:
   version "4.6.0"
@@ -2390,15 +2380,6 @@ mz@^2.4.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
-
-najax@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.4.tgz#63fd8dbf15d18f24dc895b3a16fec66c136b8084"
-  integrity sha512-wsSacA+RkgY1wxRxXCT3tdqzmamEv9PLeoV/ub9SlLf2RngbPMSqc3A7H35XJDfURC0twMmZsnPdsYPkuuFSVg==
-  dependencies:
-    jquery-deferred "^0.3.0"
-    lodash.defaultsdeep "^4.6.0"
-    qs "^6.2.0"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2877,11 +2858,6 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-
-qs@^6.2.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
-  integrity sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
 
 ramda@^0.26.1:
   version "0.26.1"


### PR DESCRIPTION
For applications that still need `najax` (for example, if they are using
an older ember-data version), they can do (example uses new
`buildSandboxGlobals` API):

```js
const najax = require('najax');

let fastboot = new FastBoot({
  distPath: 'some/path/to/dist',
  buildSandboxGlobals(globals) {
    return Object.assign({}, globals, {
      najax,
    });
  }
});
```

See #246 for more details about this change.

Closes #246