### PR TITLE
Fix invalid syntax with deferRendering.

### DIFF
--- a/src/fastboot-info.js
+++ b/src/fastboot-info.js
@@ -28,7 +28,7 @@ module.exports = class FastBootInfo {
   }
 
   deferRendering(promise) {
-    this.deferredPromise = Promise.all(this.deferredPromise, promise);
+    this.deferredPromise = Promise.all([this.deferredPromise, promise]);
   }
 
   /*

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -3,6 +3,16 @@ var FastBootInfo = require('./../src/fastboot-info.js');
 var FastBootResponse = require('./../src/fastboot-response.js');
 var FastBootRequest = require('./../src/fastboot-request.js');
 
+function delayFor(ms) {
+  let promise = new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+
+  return promise;
+}
+
 describe('FastBootInfo', function() {
   var response;
   var request;
@@ -36,5 +46,26 @@ describe('FastBootInfo', function() {
 
   it('has metadata', function() {
     expect(fastbootInfo.metadata).to.deep.equal(metadata);
+  });
+
+  it('can use deferRendering', async function() {
+    let steps = [];
+
+    steps.push('deferRendering called');
+
+    fastbootInfo.deferRendering(delayFor(10).then(() => steps.push('first delay completed')));
+    fastbootInfo.deferRendering(delayFor(10).then(() => steps.push('second delay completed')));
+    fastbootInfo.deferRendering(delayFor(20).then(() => steps.push('third delay completed')));
+    fastbootInfo.deferRendering(delayFor(15).then(() => steps.push('fourth delay completed')));
+
+    await fastbootInfo.deferredPromise;
+
+    expect(steps).to.deep.equal([
+      'deferRendering called',
+      'first delay completed',
+      'second delay completed',
+      'fourth delay completed',
+      'third delay completed',
+    ]);
   });
 });


### PR DESCRIPTION
An earlier refactor (to avoid floating the passed in `promise`) introduced invalid syntax (`Promise.all(firstThing, secondThing)`), this fixes the issue and adds tests ensuring we don't regress.