### PR TITLE
Expose option to allow a new sandbox per visit

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ configuration:
 - `shouldRender`: boolean to indicate whether the app should do rendering or not. If set to false, it puts the app in routing-only. Defaults to true.
 - `disableShoebox`: boolean to indicate whether we should send the API data in the shoebox. If set to false, it will not send the API data used for rendering the app on server side in the index.html. Defaults to false.
 - `destroyAppInstanceInMs`: whether to destroy the instance in the given number of ms. This is a failure mechanism to not wedge the Node process
+- `buildSandboxPerVisit`: whether to create a new sandbox context per-visit (slows down each visit, but guarantees no prototype leakages can occur), or reuse the existing sandbox (faster per-request, but each request shares the same set of prototypes). Defaults to false.
 
 ### Build Your App
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ class FastBoot {
    * @param {Boolean} [options.shouldRender] whether the app should do rendering or not. If set to false, it puts the app in routing-only.
    * @param {Boolean} [options.disableShoebox] whether we should send the API data in the shoebox. If set to false, it will not send the API data used for rendering the app on server side in the index.html.
    * @param {Integer} [options.destroyAppInstanceInMs] whether to destroy the instance in the given number of ms. This is a failure mechanism to not wedge the Node process (See: https://github.com/ember-fastboot/fastboot/issues/90)
-   * @param {Boolean} [options.buildSandboxPerVisit] whether to create a new sandbox context per-visit (slows down each visit, but guarantees no prototype leakages can occur), or reuse the existing sandbox (faster per-request, but each request shares the same set of prototypes)
+   * @param {Boolean} [options.buildSandboxPerVisit=false] whether to create a new sandbox context per-visit (slows down each visit, but guarantees no prototype leakages can occur), or reuse the existing sandbox (faster per-request, but each request shares the same set of prototypes)
    * @returns {Promise<Result>} result
    */
   async visit(path, options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ class FastBoot {
    * @param {Boolean} [options.shouldRender] whether the app should do rendering or not. If set to false, it puts the app in routing-only.
    * @param {Boolean} [options.disableShoebox] whether we should send the API data in the shoebox. If set to false, it will not send the API data used for rendering the app on server side in the index.html.
    * @param {Integer} [options.destroyAppInstanceInMs] whether to destroy the instance in the given number of ms. This is a failure mechanism to not wedge the Node process (See: https://github.com/ember-fastboot/fastboot/issues/90)
+   * @param {Boolean} [options.buildSandboxPerVisit] whether to create a new sandbox context per-visit (slows down each visit, but guarantees no prototype leakages can occur), or reuse the existing sandbox (faster per-request, but each request shares the same set of prototypes)
    * @returns {Promise<Result>} result
    */
   async visit(path, options = {}) {

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -401,30 +401,30 @@ describe('FastBoot', function() {
       });
   });
 
-  it('in app prototype mutations do not leak across visits', async function() {
+  it('in app prototype mutations do not leak across visits with buildSandboxPerVisit=true', async function() {
     this.timeout(3000);
 
     var fastboot = new FastBoot({
       distPath: fixture('app-with-prototype-mutations'),
     });
 
-    let result = await fastboot.visit('/');
+    let result = await fastboot.visit('/', { buildSandboxPerVisit: true });
     let html = await result.html();
 
     expect(html).to.match(/Items: 1/);
 
-    result = await fastboot.visit('/');
+    result = await fastboot.visit('/', { buildSandboxPerVisit: true });
     html = await result.html();
 
     expect(html).to.match(/Items: 1/);
 
-    result = await fastboot.visit('/');
+    result = await fastboot.visit('/', { buildSandboxPerVisit: true });
     html = await result.html();
 
     expect(html).to.match(/Items: 1/);
   });
 
-  it('errors can be properly attributed', async function() {
+  it('errors can be properly attributed with buildSandboxPerVisit=true', async function() {
     this.timeout(3000);
 
     var fastboot = new FastBoot({
@@ -432,14 +432,17 @@ describe('FastBoot', function() {
     });
 
     let first = fastboot.visit('/slow/100/reject', {
+      buildSandboxPerVisit: true,
       request: { url: '/slow/100/reject', headers: {} },
     });
 
     let second = fastboot.visit('/slow/50/resolve', {
+      buildSandboxPerVisit: true,
       request: { url: '/slow/50/resolve', headers: {} },
     });
 
     let third = fastboot.visit('/slow/25/resolve', {
+      buildSandboxPerVisit: true,
       request: { url: '/slow/25/resolve', headers: {} },
     });
 


### PR DESCRIPTION
This PR does a few things:

Firstly, it allows the end consumer to decide if they want a sandbox per visit or to share a single sandbox over all visits.

Second, it changes the default of `buildSandboxPerVisit` back to `false` therefore sharing a single sandbox for many `visit` invocations.

Reverts the defaults change introduced in #236.