### PR TITLE
Restore result finalization in resilient mode

### DIFF
--- a/src/ember-app.js
+++ b/src/ember-app.js
@@ -328,12 +328,11 @@ class EmberApp {
         // if shoebox is not disabled, then create the shoebox and send API data
         createShoebox(doc, fastbootInfo);
       }
-
-      result._finalize();
     } catch (error) {
       // eslint-disable-next-line require-atomic-updates
       result.error = error;
     } finally {
+      result._finalize();
       // ensure we invoke `Ember.Application.destroy()` and
       // `Ember.ApplicationInstance.destroy()`, but use `result._destroy()` so
       // that the `result` object's internal `this.isDestroyed` flag is correct

--- a/test/fastboot-test.js
+++ b/test/fastboot-test.js
@@ -242,7 +242,10 @@ describe('FastBoot', function() {
 
     return fastboot
       .visit('/')
-      .then(r => r.html())
+      .then(r => {
+        expect(r.finalized).to.be.true;
+        return r.html();
+      })
       .then(html => {
         expect(html).to.match(/<body>/);
       });


### PR DESCRIPTION
Previous version 2.x always finalised the result https://github.com/ember-fastboot/fastboot/blob/v2.0.3/src/ember-app.js#L363.

This PR restores that behaviour, which should unlock ember-fastboot/fastboot-express-middleware#70.