### PR TITLE
Remove node version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/ember-fastboot/fastboot.svg)](https://greenkeeper.io/)
 [![npm version](https://badge.fury.io/js/fastboot.svg)](https://badge.fury.io/js/fastboot)
 [![Build Status](https://travis-ci.org/ember-fastboot/fastboot.svg?branch=master)](https://travis-ci.org/ember-fastboot/fastboot)
-![Ember Version](https://embadge.io/v1/badge.svg?start=2.3.0)
 
 FastBoot is a library for rendering Ember.js applications in Node.js.
 
@@ -16,8 +15,6 @@ prerequisite for developing FastBoot apps.
 To serve server-rendered versions of your Ember app over HTTP, see the
 [FastBoot App
 Server](https://github.com/ember-fastboot/fastboot-app-server).
-
-FastBoot requires Node.js v6 or later.
 
 ## Usage
 


### PR DESCRIPTION
It's covered in package.json engines.
Also removes https://embadge.io badge which seems unavailable.